### PR TITLE
Fix/TextToColumn - Table Or View Not Found

### DIFF
--- a/gems/TextToColumns.py
+++ b/gems/TextToColumns.py
@@ -227,7 +227,7 @@ class TextToColumns(MacroSpec):
 
     def onChange(self, context: SqlContext, oldState: Component, newState: Component) -> Component:
         # Handle changes in the newState's state and return the new state
-        relation_name = self.get_relation_names(component, context)
+        relation_name = self.get_relation_names(newState, context)
         return (replace(newState, properties=replace(newState.properties, relation_name=relation_name)))
 
     def apply(self, props: TextToColumnsProperties) -> str:


### PR DESCRIPTION
**Error Description**

Error appears in TextToColumn gem configuration but is resolved on save without fixing.

Split to Rows error:
The table or view `r` cannot be found. Verify the spelling and correctness of the schema and catalog.

Split to Columns error: 
org.apache.spark.sql.catalyst.parser.ParseException: 
[PARSE_SYNTAX_ERROR] Syntax error at or near ')'. SQLSTATE: 42601 
Save without fixing
Now the error is removed

Screenshots
1. Running pipeline screenshot
![image](https://github.com/user-attachments/assets/e92147ce-9425-44d6-9149-6de4be20140b)

2. Successful compilation screenshot (Split to columns)
![image](https://github.com/user-attachments/assets/e1633df8-a458-4a45-8e6a-20bf7db7ce93)

3. Successful compilation screenshot (Split to rows)
![image](https://github.com/user-attachments/assets/1a40d735-7e32-4e3c-820d-0aa570127371)
