### PR TITLE
Dynamic Select - ComplexExpression support

### DIFF
--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'DatabricksSqlBasics',
-    version = '0.0.10',
+    version = '0.0.11.dev0',
     packages = ['DatabricksSqlBasics'],
     package_dir = {'DatabricksSqlBasics': '.'},
     description = '',

--- a/macros/DynamicSelect.sql
+++ b/macros/DynamicSelect.sql
@@ -15,17 +15,21 @@
     {%- set selected_columns = [] -%}
     {%- for column in enriched_schema -%}
         {%- if selectUsing == 'SELECT_EXPR' -%}
-                {# Evaluate the custom expression by substituting column name in the expression #}
-                {%- if "column_name" in customExpression -%}
-                {%- set expression_to_evaluate = customExpression.replace("column_name", "'" ~ column["name"] ~ "'") -%}
+                {%- set expression_to_evaluate = customExpression -%}
+
+                {%- if "column_name" in expression_to_evaluate -%}
+                    {%- set expression_to_evaluate = expression_to_evaluate.replace(
+                        "column_name", "'" ~ column["name"] ~ "'") -%}
                 {%- endif -%}
 
-                {%- if "column_type" in customExpression -%}
-                {%- set expression_to_evaluate = customExpression.replace("column_type", "'" ~ column["dataType"] ~ "'") -%}
+                {%- if "column_type" in expression_to_evaluate -%}
+                    {%- set expression_to_evaluate = expression_to_evaluate.replace(
+                        "column_type", "'" ~ column["dataType"] ~ "'") -%}
                 {%- endif -%}
 
-                {%- if "field_number" in customExpression -%}
-                {%- set expression_to_evaluate = customExpression.replace("field_number", "'" ~ column["column_index"] ~ "'") -%}
+                {%- if "field_number" in expression_to_evaluate -%}
+                    {%- set expression_to_evaluate = expression_to_evaluate.replace(
+                        "field_number", "'" ~ column["column_index"] ~ "'") -%}
                 {%- endif -%}
 
                 {%- set evaluation_result = DatabricksSqlBasics.evaluate_expression(expression_to_evaluate) | trim -%}

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: DatabricksSqlBasics
 description: ''
-version: 0.0.10
+version: 0.0.11.dev0
 author: abhisheks+e2etests@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
Asana: https://app.asana.com/0/search/1210599824984022/1210611677703052/f

Scenario: 
Gem is working with one of the options (column_name/column_type/field_number). But when we are mixing the options like 
```
contains(column_name,'Number') OR column_type in ('Float') OR field_number in (0,1)
```
Then gem is getting broken.

Test Evidence post fix
![image](https://github.com/user-attachments/assets/b7b800bd-09ac-4de8-bbcb-c1b825632940)

![image](https://github.com/user-attachments/assets/eb182e0e-f24e-4e8f-8e6e-061839cbc51b)


